### PR TITLE
修复#4 修改部分库为相对引用，方便作为库来使用

### DIFF
--- a/mdict_query.py
+++ b/mdict_query.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 
-from readmdict import MDX, MDD
+from .readmdict import MDX, MDD
 from struct import pack, unpack
 from io import BytesIO
 import re

--- a/readmdict.py
+++ b/readmdict.py
@@ -23,8 +23,8 @@ import re
 import sys
 import json
 
-from ripemd128 import ripemd128
-from pureSalsa20 import Salsa20
+from .ripemd128 import ripemd128
+from .pureSalsa20 import Salsa20
 
 # zlib compression is used for engine version >=2.0
 import zlib


### PR DESCRIPTION
注意：请不要使用pip上的readmdict，必须使用当前项目当中的`readmdict.py`